### PR TITLE
A trivial bug. A typo in loadData. On line 81.

### DIFF
--- a/pmtkTools/dataTools/loadData.m
+++ b/pmtkTools/dataTools/loadData.m
@@ -78,7 +78,7 @@ else % download zip file and unzip
     % SS check if file exists
     [info,msg,err] = stat(dest);
     if (msg == 0)
-      fprintf("%s exists, no need to download",dest);
+      fprintf('%s exists, no need to download',dest);
     else
 
     ok     = downloadFile(source, dest);


### PR DESCRIPTION
As I described in the issue I raised - Line 81 in loadData.m uses the incorrect quote mark, which then means the %s doesn't work as intended and instead comments out the rest of the line resulting in a script failure and this then causes testpmtk3.m to ask you to check internet connection or perl installation.

```
fprintf("%s exists, no need to download",dest);
```

should be:

```
fprintf('%s exists, no need to download',dest);
```

That fixed the problem for me. So I have submitted this pull request.

Sorry if this isn't the correct way to do this - I'm kind of new.

Many thanks,

Alexander.
