### PR TITLE
changed illigle double quotation marks to single

### DIFF
--- a/pmtkTools/dataTools/loadData.m
+++ b/pmtkTools/dataTools/loadData.m
@@ -78,7 +78,7 @@ else % download zip file and unzip
     % SS check if file exists
     [info,msg,err] = stat(dest);
     if (msg == 0)
-      fprintf("%s exists, no need to download",dest);
+      fprintf('%s exists, no need to download',dest);
     else
 
     ok     = downloadFile(source, dest);


### PR DESCRIPTION
Double quotation marks are illigal in matlab syntax. This is just a trivial bug but gives confusing error message.
