### PR TITLE
Ars fix

### DIFF
--- a/toolbox/Algorithms/mcmc/ars.m
+++ b/toolbox/Algorithms/mcmc/ars.m
@@ -137,17 +137,15 @@ end
 
 upperHull = [];
 
-if isinf(domain(1))
-	% first line (from -infinity)
-	m = (fS(2)-fS(1))/(S(2)-S(1));
-	b = fS(1) - m*S(1);
-	pr = exp(b)/m * ( exp(m*S(1)) - 0 ); % integrating in from -infinity
-	upperHull(1).m = m;
-	upperHull(1).b = b;
-	upperHull(1).pr = pr;
-	upperHull(1).left = -inf;
-	upperHull(1).right = S(1);
-end
+% first line (from boundary)
+m = (fS(2)-fS(1))/(S(2)-S(1));
+b = fS(1) - m*S(1);
+pr = exp(b)/m * ( exp(m*S(1)) - 0 ); % integrating in from -infinity
+upperHull(1).m = m;
+upperHull(1).b = b;
+upperHull(1).pr = pr;
+upperHull(1).left = domain(1);
+upperHull(1).right = S(1);
 
 % second line
 m = (fS(3)-fS(2))/(S(3)-S(2));
@@ -202,18 +200,17 @@ upperHull(i).pr = pr;
 upperHull(i).left = S(end-1);
 upperHull(i).right = S(end);
 
-if isinf(domain(2))
-	% last line (to infinity)
-	m = (fS(end)-fS(end-1))/(S(end)-S(end-1));
-	b = fS(end) - m*S(end);
-	pr = exp(b)/m * ( 0 - exp(m*S(end)) );
-	i = length(upperHull)+1;
-	upperHull(i).m = m;
-	upperHull(i).b = b;
-	upperHull(i).pr = pr;
-	upperHull(i).left = S(end);
-	upperHull(i).right = inf;
-end
+% last line (to boundary)
+m = (fS(end)-fS(end-1))/(S(end)-S(end-1));
+b = fS(end) - m*S(end);
+pr = exp(b)/m * ( 0 - exp(m*S(end)) );
+i = length(upperHull)+1;
+upperHull(i).m = m;
+upperHull(i).b = b;
+upperHull(i).pr = pr;
+upperHull(i).left = S(end);
+upperHull(i).right = domain(2);
+
 
 Z = sum([upperHull(:).pr]);
 for li=1:length(upperHull)

--- a/toolbox/Algorithms/mcmc/ars.m
+++ b/toolbox/Algorithms/mcmc/ars.m
@@ -83,12 +83,12 @@ while 1
 	meshChanged = 0; % flag to indicate if a new point has been added to the mesh
 
 	% three cases for acception/rejection
-	if U<=lhVal/uhVal,
+	if U<=exp(lhVal - uhVal),
 		% accept, u is below lower bound
 		nSamplesNow = nSamplesNow + 1;
 		samples(nSamplesNow) = x;
 
-	elseif U<=func(x, varargin{:})/uhVal
+	elseif U<=exp(func(x, varargin{:}) - uhVal)
 		% accept, u is between lower bound and f
 		nSamplesNow = nSamplesNow + 1;
 		samples(nSamplesNow) = x;


### PR DESCRIPTION
There are two fixed bugs:

1. The first fix relates to bug https://github.com/probml/pmtk3/issues/61. The code is treating hull values as probabilities but they are computed in log space. This lead to higher acceptance rate. For example, with normal distribution:
```
function ys = funcNormal(xs)
       sigma = 1.0;
       ys = -(xs.*xs) / sigma;
end

samples = ars(@funcNormal, -1.0, 1.0, [-inf,inf], 10000);
hist(samples,30);
qqplot(samples);
```
![screen shot 2015-01-19 at 12 02 34](https://cloud.githubusercontent.com/assets/5541162/5800458/c31ee54a-9fd6-11e4-849f-4b8ec3adf3da.png)
QQ plot shows that the resulting samples are not from the standard normal distribution.
![screen shot 2015-01-19 at 12 02 08](https://cloud.githubusercontent.com/assets/5541162/5800460/c693fd46-9fd6-11e4-9c04-9f1241f53ec7.png)

With fix https://github.com/evelinag/pmtk3/commit/4f881a5132718281742e346d0bc2f09480e6cd45, the result looks as follows:
![screen shot 2015-01-19 at 12 03 40](https://cloud.githubusercontent.com/assets/5541162/5800483/ff4f7296-9fd6-11e4-9ad5-714691a2a855.png)
![screen shot 2015-01-19 at 12 03 55](https://cloud.githubusercontent.com/assets/5541162/5800486/0196bb90-9fd7-11e4-823a-073666b6fbca.png)

2. The second bug was in the way how bounded distributions were treated. If the domain where a distribution is defined is not infinite, the area between initial points and boundaries of the interval was ignored. For example for Beta distribution which is defined on [0,1]: 
```
function ys = funcBeta(xs)
    a = 2; b = 5; 
    ys = (a - 1) .* log(xs) + (b - 1) .* log(1 - xs);
end

samples = ars(@funcBeta, 0.1, 0.8, [0, 1], 10000);
hist(samples,30);
```
![screen shot 2015-01-19 at 12 19 35](https://cloud.githubusercontent.com/assets/5541162/5800548/c97a0f22-9fd7-11e4-9244-4602c8f9d7a5.png)

With fix https://github.com/evelinag/pmtk3/commit/a0e800f58429dac8fd8d9ec5e194ca7fe722661e, `ars` samples from the full interval.
![screen shot 2015-01-19 at 12 20 22](https://cloud.githubusercontent.com/assets/5541162/5800561/01d2758a-9fd8-11e4-9c48-26adb3bb247f.png)
