### PR TITLE
Changed initPmtk3.m to pass ~ instead of no value 

### DIFF
--- a/initPmtk3.m
+++ b/initPmtk3.m
@@ -46,7 +46,7 @@ if exist(source, 'dir')
     fprintf('adding %s to path\n', source);
 end
 if ~(exist('pmtkSupportRoot', 'file') == 2)
-    downloadAllSupport();
+    downloadAllSupport(~,~);
 end
 
 %% include graphViz 


### PR DESCRIPTION
for destnRoot and quiet vars. I was not able to reproduce the bug in #95 on OS X, but this is what allowed it to work for Windows 7 and Matlab 2014b on my other machine. This may not be the cleanest solution however. I believe this should fix #95.