### PR TITLE
fix bug when we compute the means of messages from skill to game

### DIFF
--- a/demos/trueskillDemo.m
+++ b/demos/trueskillDemo.m
@@ -107,7 +107,7 @@ for iter=1:5
   % compute this first because it is needed for the mean update
   Psg = Ps(G) - Pgs;
   %Msg = (Ps(G).*Ms(G) - Pgs.*Mgs)./Ps(G); 
-  Msg = (Ps(G).*Ms(G) - Pgs.*Mgs)./Psg(G); % KPM 
+  Msg = (Ps(G).*Ms(G) - Pgs.*Mgs)./Psg; % KPM 
      
   % (3) compute game to performance messages
   vgt = 1 + sum(1./Psg, 2);


### PR DESCRIPTION
I have figured this bug of ```TrueSkillDemo.m ```. We dont need to organize ```Psg``` by matrix ```G``` during the computation of means of messages from skill to game.

Before fixing, I also reference to the [implementation of Cambridge's 4f13 class.](http://mlg.eng.cam.ac.uk/teaching/4f13/1516/cw/eprank.m)