### PR TITLE
Fix the randomize logic in kfold

### DIFF
--- a/matlabTools/stats/Kfold.m
+++ b/matlabTools/stats/Kfold.m
@@ -20,10 +20,6 @@ function  [trainfolds, testfolds] = Kfold(N, K, randomize)
 
 if nargin < 3, randomize = 0; end
 if randomize
-  S = rand('state');
-  rand('state',0);
-  rand('state',S)
-  %setSeed(0);
   perm = randperm(N);
 else
     perm = 1:N;
@@ -48,10 +44,6 @@ for i=1:K
     testfolds{i} = perm(testfolds{i});
     trainfolds{i} = perm(trainfolds{i});
     ndx = ndx+Nbin(i);
-end
-
-if randomize
-    restoreSeed;
 end
 
 end


### PR DESCRIPTION
The function is not taking any seed argument to perform controlled randomization. The random generator was being reset and then restored again for no reason. The restoreSeed function which was later invoked was erroring out because the global variables were not set.
