### PR TITLE
Update for undefined variable expressions as of Matlab R2015b.

### DIFF
--- a/matlabTools/util/SetDefaultValue.m
+++ b/matlabTools/util/SetDefaultValue.m
@@ -21,6 +21,7 @@ function SetDefaultValue(position, argName, defaultValue)
 % This file is from pmtk3.googlecode.com
 
 if evalin('caller', 'nargin') < position || ...
+      ~evalin('caller', ['exist(''' argName ''', ''var'')']) || ...
       isempty(evalin('caller', argName))
    assignin('caller', argName, defaultValue);
 end


### PR DESCRIPTION
Fixes #125 

Per comments in the original library:
https://www.mathworks.com/matlabcentral/fileexchange/27056-set-default-values

Tested on Mac Matlab version R2015b, 8.6.0.267246.