### PR TITLE
fixes issue computing the tabular CPD

### DIFF
--- a/toolbox/GraphicalModels/cpd/condDiscreteProdCpdCreate.m
+++ b/toolbox/GraphicalModels/cpd/condDiscreteProdCpdCreate.m
@@ -41,15 +41,17 @@ function CPD = condDiscreteProdCpdFit(CPD, Z, Y)
 %%
 nstates = CPD.nstates;
 nObsStates = CPD.nObsStates; 
-T = CPD.T;
 if isempty(CPD.prior)
     alpha = 1;
 else
     alpha = CPD.prior.alpha;
 end
+T = zeros(size(CPD.T));
 for k = 1:nstates
-   T(k, :, :) = normalize(histc(Y(Z==k, :) + alpha - 1, 1:nObsStates), 2); 
+    obsCounts = histc(Y(Z==k, :), 1:nObsStates, 1) + alpha - 1;
+    T(k, :, :) = normalize(obsCounts, 1); 
 end
+CPD.T = T;
 end
 
 function ess = condDiscreteProdCpdComputeEss(cpd, data, weights, B)


### PR DESCRIPTION
There are three issues with `condDiscreteProdCpdFit`:

1. the tabular cpd `T` is computed but not returned. 

2.  as far as I understand, `alpha` should not be added to the observations but rather to the counts.

3. `histc` should specify the dimension over which it operates. Otherwise, it doesn't work if `Y(Z==k, :)` has only one row.

This can be tested with the following code:
```
states{1} = [1, 1, 1, 2, 2, 3, 1];   
observations{1} = [1, 1, 1, 2, 2, 3, 1];  
model = hmmFitFullyObs(states, observations, 'discrete');  
decodedFromTrueViterbi = hmmMap(model, observations{1});  
assert(isequal(decodedFromTrueViterbi, states{1}));  
```